### PR TITLE
Fix compile warning

### DIFF
--- a/source/Pixels.cpp
+++ b/source/Pixels.cpp
@@ -60,16 +60,16 @@ const Color& Pixels::get(size_t x, size_t y) const {
 }
 
 Pixels::Pixels(const Pixels &other) :
-        imageHeight(other.imageHeight),
-        imageWidth(other.imageWidth) {
+        imageWidth(other.imageWidth),
+        imageHeight(other.imageHeight) {
 
     colors = new Color[imageHeight * imageWidth];
     std::copy_n(other.colors, imageHeight * imageWidth, colors);
 }
 
 Pixels::Pixels(Pixels &&other) noexcept :
-               imageHeight(other.imageHeight),
-               imageWidth(other.imageWidth) {
+               imageWidth(other.imageWidth),
+               imageHeight(other.imageHeight) {
     other.imageHeight = 0;
     other.imageWidth = 0;
     colors = other.colors;

--- a/source/Pixels.h
+++ b/source/Pixels.h
@@ -6,7 +6,7 @@
 namespace sglib {
     class Pixels {
     public:
-        Pixels() : imageHeight(0), imageWidth(0), colors(nullptr) { }
+        Pixels() : imageWidth(0), imageHeight(0), colors(nullptr) { }
         Pixels(size_t width, size_t height);
         Pixels(size_t width, size_t height, const Color& color);
         Pixels(const Pixels& other);


### PR DESCRIPTION
Hello~ I get some warnings when compiling:

# bazel build -c opt //source:main
INFO: Build option --compilation_mode has changed, discarding analysis cache.
INFO: Analyzed target //source:main (0 packages loaded, 177 targets configured).
INFO: Found 1 target...
INFO: From Compiling source/Canvas.cpp:
In file included from source/Canvas.cpp:1:
In file included from source/Canvas.h:2:
source/Pixels.h:9:20: warning: field 'imageHeight' will be initialized after field 'imageWidth' [-Wreorder-ctor]
        Pixels() : imageHeight(0), imageWidth(0), colors(nullptr) { }
                   ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~
                   imageWidth(0)   imageHeight(0)
1 warning generated.
INFO: From Compiling source/LinearGradient.cpp:
In file included from source/LinearGradient.cpp:1:
In file included from source/LinearGradient.h:4:
source/Pixels.h:9:20: warning: field 'imageHeight' will be initialized after field 'imageWidth' [-Wreorder-ctor]
        Pixels() : imageHeight(0), imageWidth(0), colors(nullptr) { }
                   ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~
                   imageWidth(0)   imageHeight(0)


I adjusted the initialization order of member variables in the constructor to avoid these warnings.